### PR TITLE
[ADD] fertinova: Add accounting_date in stock.picking

### DIFF
--- a/fertinova/__manifest__.py
+++ b/fertinova/__manifest__.py
@@ -32,6 +32,7 @@
         'wizards/internal_transfer_multicurrency_view.xml',
         'views/account_payment.xml',
         'views/sale_views.xml',
+        'views/stock_picking_views.xml',
     ],
     'demo': [
     ],

--- a/fertinova/i18n/es.po
+++ b/fertinova/i18n/es.po
@@ -16,6 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: fertinova
+#: model:ir.model.fields,field_description:fertinova.field_stock_picking__accounting_date
+msgid "Force Accounting Date"
+msgstr "Forzar Fecha contable"
+
+#. module: fertinova
 #: model:ir.model.fields,field_description:fertinova.field_internal_transfer_multicurrency__agreed_amount
 msgid "Agreed Amount"
 msgstr "Monto acordado"
@@ -59,6 +64,11 @@ msgstr "Creado el"
 #: model:ir.model.fields,field_description:fertinova.field_internal_transfer_multicurrency__currency_id
 msgid "Currency"
 msgstr "Moneda"
+
+#. module: fertinova
+#: model:ir.model.fields,help:fertinova.field_stock_picking__accounting_date
+msgid "Date at which the accounting entries will be created in case of automated product in picking. If empty, the stock picking date will be used."
+msgstr "Fecha en la que los asientos contables se crearán en  caso de que se trate de un producto automatizado en la transferencia. Si está vacío, se usará la fecha de la transferencia."
 
 #. module: fertinova
 #: model:ir.model.fields,field_description:fertinova.field_internal_transfer_multicurrency__display_name

--- a/fertinova/models/__init__.py
+++ b/fertinova/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import res_currency
 from . import sale
+from . import stock_picking

--- a/fertinova/models/stock_picking.py
+++ b/fertinova/models/stock_picking.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Vauxoo
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class Picking(models.Model):
+    _inherit = 'stock.picking'
+
+    accounting_date = fields.Date(
+        string='Force Accounting Date',
+        help="Date at which the accounting entries will be created"
+        " in case of automated product in picking.  If empty, the "
+        "stock picking date will be used.")
+
+    @api.multi
+    def action_done(self):
+        """Inherit method to add for context the accounting_date in the
+        account_entry and change the debit and credit quantity for each entry
+        created, if the accounting_date field is set."""
+        with_acc_date = self.filtered('accounting_date')
+        wo_acc_date = self - with_acc_date
+        res = super(Picking, wo_acc_date).action_done()
+        for picking in with_acc_date:
+            res = super(Picking, picking.with_context(
+                force_period_date=picking.accounting_date)).action_done()
+            move_purchase = picking.move_lines.filtered(
+                lambda move: move.purchase_line_id)
+            for move in move_purchase:
+                unit_price = move.purchase_line_id.price_unit
+                company_currency = picking.company_id.currency_id
+
+                if (move.purchase_line_id.currency_id != company_currency):
+                    unit_price = move.purchase_line_id.currency_id._convert(
+                        unit_price, company_currency,
+                        picking.company_id, picking.accounting_date)
+
+                account_moves = move.account_move_ids
+                cost = move.product_qty * unit_price
+                account_moves.button_cancel()
+                for account_move in account_moves:
+                    debit_move_line = account_move.line_ids.filtered(
+                        lambda move_line: move_line.debit > 0)
+                    debit_move_line.with_context(
+                        check_move_validity=False).write({
+                            'debit': cost
+                            })
+                    credit_move_line = account_move.line_ids.filtered(
+                        lambda move_line: move_line.credit > 0)
+                    credit_move_line.with_context(
+                        check_move_validity=False).write({
+                            'credit': cost
+                            })
+                account_moves.post()
+        return res

--- a/fertinova/views/stock_picking_views.xml
+++ b/fertinova/views/stock_picking_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_form_inherit" model="ir.ui.view">
+        <field name="name">stock.picking.form.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='origin']" position="after">
+                <field name="accounting_date" attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}" groups="account.group_account_invoice"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_picking_tree_inherit" model="ir.ui.view">
+        <field name="name">stock.picking.tree.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.vpicktree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='scheduled_date']" position="after">
+                <field name="accounting_date"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_inventory_form_inherit_fertinova" model="ir.ui.view">
+        <field name="name">stock.inventory.form.inherit.fertinova</field>
+        <field name="model">stock.inventory</field>
+        <field name="inherit_id" ref="stock.view_inventory_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='accounting_date']" position="attributes">
+                <attribute name="groups">account.group_account_invoice</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add field accounting_date to the stock.picking model and view.
![Field Accounting Date](https://user-images.githubusercontent.com/26889951/67888903-883a8e00-fb13-11e9-973f-85ea131f4bc4.png)

- Add an inherited method in stock.picking (action_done) to add for context the accounting_date in the account.move.
- Add translation for the new field.
- Change groups attribute of the field accounting_date from stock_account module to "account.group_account_invoice".