### PR TITLE
[REF] Pass context when opening stock moves view

### DIFF
--- a/fertinova_addons/models/stock_quant_inherited.py
+++ b/fertinova_addons/models/stock_quant_inherited.py
@@ -23,7 +23,7 @@ class StockQuant(models.Model):
         action = super(StockQuant, self.with_context(location_id=self.location_id.id)).action_view_stock_moves()
         # Or this:
         ctx = eval(action.get('context'))
-        ctx.update({'location_id': self.location_id.od})
+        ctx.update({'location_id': self.location_id.id})
         action['context'] = str(ctx)
         # End Hugho-ad Code:
 

--- a/fertinova_addons/models/stock_quant_inherited.py
+++ b/fertinova_addons/models/stock_quant_inherited.py
@@ -16,7 +16,16 @@ class StockQuant(models.Model):
         This is made by entering into STOCK > MAIN DATA {Menu} > PRODUCTS {Menuitem} > a given product > Smart Button {action_open_quants}"""
         
         #Calling in order to extend method 'action_view_stock_moves':
-        action = super(StockQuant, self).action_view_stock_moves()
+        # HERE IS WHERE WE NEED PASS THE LOCATION
+        
+        # Hugho-ad Code:
+        # Try this option:
+        action = super(StockQuant, self.with_context(location_id=self.location_id.id)).action_view_stock_moves()
+        # Or this:
+        ctx = action.get('context') or {}
+        ctx.update({'location_id': self.location_id.od})
+        action['context'] = str(ctx)
+        # End Hugho-ad Code:
 
         #Add location_id into the context:
         self = self.with_context(location_id=self.location_id.id)  

--- a/fertinova_addons/models/stock_quant_inherited.py
+++ b/fertinova_addons/models/stock_quant_inherited.py
@@ -22,7 +22,7 @@ class StockQuant(models.Model):
         # Try this option:
         action = super(StockQuant, self.with_context(location_id=self.location_id.id)).action_view_stock_moves()
         # Or this:
-        ctx = action.get('context') or {}
+        ctx = eval(action.get('context'))
         ctx.update({'location_id': self.location_id.od})
         action['context'] = str(ctx)
         # End Hugho-ad Code:


### PR DESCRIPTION
action_view_stock_moves was inherited in order to pass location_id when opening stock moves from smart button on quant view, this 
 in order to allow computing transfers field to take into account the location id and show negative qty.